### PR TITLE
Modify so works

### DIFF
--- a/07-Structure-from-motion.ipynb
+++ b/07-Structure-from-motion.ipynb
@@ -97,8 +97,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "!conda install plotly -y"
+    "%%bash\n",
+    "conda init\n",
+    ". ~/.bashrc\n",
+    "conda activate open3d\n",
+    "python -m ipykernel install --user --name=open3d"
    ]
   },
   {
@@ -114,9 +125,9 @@
     "import os\n",
     "import sys\n",
     "import pathlib\n",
-    "import open3d as o3d\n",
-    "import plotly\n",
-    "import plotly.graph_objects as go"
+    "# import open3d as o3d\n",
+    "# import plotly\n",
+    "# import plotly.graph_objects as go"
    ]
   },
   {
@@ -434,25 +445,43 @@
    },
    "outputs": [],
    "source": [
+    "%%bash\n",
+    ". ~/.bashrc\n",
+    "conda activate opensfm\n",
+    "export MPLBACKEND=\"svg\"\n",
+    "export PATH=$PATH:/opt/utils/OpenSfM/bin/\n",
     "# Take initial guess of intrinsic parameters through metadata\n",
-    "!opensfm extract_metadata kitchen_example/\n",
+    "opensfm extract_metadata kitchen_example/\n",
     "\n",
     "# Detect features points \n",
-    "!opensfm detect_features kitchen_example/\n",
+    "opensfm detect_features kitchen_example/\n",
     "\n",
     "# Match feature points across images\n",
-    "!opensfm match_features kitchen_example/\n",
+    "opensfm match_features kitchen_example/\n",
     "\n",
     "# This creates \"tracks\" for the features. That is to say, if a feature in image 1 is matched with one in image 2,\n",
     "# and in turn that one is matched with one in image 3, then it links the matches between 1 and 3. In this case, \n",
     "# it does not matter since we only have two images\n",
-    "!opensfm create_tracks kitchen_example/\n",
+    "opensfm create_tracks kitchen_example/\n",
     "\n",
     "# Calculates the essential matrix, the camera pose and the reconstructed feature points\n",
-    "!opensfm reconstruct kitchen_example/\n",
+    "opensfm reconstruct kitchen_example/\n",
     "\n",
     "# For visualization using Open3D\n",
-    "!opensfm export_ply kitchen_example/"
+    "opensfm export_ply kitchen_example/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SWITCH to open3d here\n",
+    "import open3d as o3d\n",
+    "import plotly\n",
+    "import plotly.graph_objects as go\n",
+    "import numpy as np"
    ]
   },
   {
@@ -477,9 +506,9 @@
     "                col_idx += 1\n",
     "            if header_done:\n",
     "                line_list = line.split()\n",
-    "                colors.append([float(line_list[columns['diffuse_red']]),\n",
-    "                              float(line_list[columns['diffuse_green']]),\n",
-    "                              float(line_list[columns['diffuse_blue']])\n",
+    "                colors.append([float(line_list[columns['red']]),\n",
+    "                              float(line_list[columns['green']]),\n",
+    "                              float(line_list[columns['blue']])\n",
     "                              ])\n",
     "            if line.startswith('end_header'):\n",
     "                header_done = True\n",
@@ -538,7 +567,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!opensfm undistort kitchen_example/"
+    "%%bash\n",
+    ". ~/.bashrc\n",
+    "conda activate opensfm\n",
+    "export MPLBACKEND=\"svg\"\n",
+    "export PATH=$PATH:/opt/utils/OpenSfM/bin/\n",
+    "\n",
+    "opensfm undistort kitchen_example/"
    ]
   },
   {
@@ -547,7 +582,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!opensfm compute_depthmaps kitchen_example/"
+    "%%bash\n",
+    ". ~/.bashrc\n",
+    "conda activate opensfm\n",
+    "export MPLBACKEND=\"svg\"\n",
+    "export PATH=$PATH:/opt/utils/OpenSfM/bin/\n",
+    "\n",
+    "opensfm compute_depthmaps kitchen_example/"
    ]
   },
   {
@@ -630,9 +671,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "open3d",
    "language": "python",
-   "name": "python3"
+   "name": "open3d"
   },
   "language_info": {
    "codemirror_mode": {
@@ -644,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This adds a set of changes that makes the notebook run in the environment without installing any new packages. In summary:

 - The normal/base environment is used for the SfM matching demonstration
 - Cells that use OpenSFM have been modified to add OpenSFM to the PATH
 - The open3d environment is used for the second half of the notebook, which requires plotly/open3d to export the visualizations

